### PR TITLE
Fixed issue with characters being removed during replace

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ function ReplaceStream(search, replace, options) {
         tail = part;
       } else {
         totalMatches++;
+
         rewritten += before + replace;
         tail = '';
       }
@@ -37,8 +38,17 @@ function ReplaceStream(search, replace, options) {
     }
 
     if (matchCount) {
-      after = haystack.slice(lastPos, haystack.length - tail.length);
-      this.queue(rewritten + after);
+      after = haystack.slice(lastPos, haystack.length);
+
+      if(tail.length + after.length < search.length){
+        tail += after;
+      }
+      else{
+        rewritten += tail +after;
+        tail = '';
+      }
+
+      this.queue(rewritten);
     } else if (tail) {
       this.queue(haystack);
       tail = '';

--- a/test/replace.js
+++ b/test/replace.js
@@ -10,8 +10,34 @@ function script(inner) {
     '</script>'
   ].join('\n');
 }
-
 describe('replace', function () {
+  it('should only replace characters specified', function (done) {
+    var haystack = [
+      'ab',
+      'a',
+      'b'
+    ].join('\n');
+
+    var acc = '';
+    var replace = replaceStream('ab','Z');
+    replace.on('data', function (data) {
+      acc += data;
+    });
+    replace.on('end', function () {
+        var expected = [
+        'Z',
+        'a',
+        'b'
+      ].join('\n');
+
+      expect(acc).to.equal(expected);
+      done();
+    });
+
+    replace.write(haystack);
+    replace.end();
+  });
+
   it('should be able to replace within a chunk', function (done) {
     var haystack = [
       '<!DOCTYPE html>',


### PR DESCRIPTION
In cases where the a character of the string that was to be replaced was found a partial match would occur.  However, the logic would place misplace the partial match in a different position in the resulting output.  In addition, some cases the result would skip some characters at the end of the stream. This fix calculates and appends the tail of the stream based on the remaining stream buffer and the match.

Fixes #3
