### PR TITLE
Updated to allow for multiple partial matches.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,12 @@ function ReplaceStream(search, replace, options) {
       var part = matches[0];
       before = haystack.slice(lastPos, matches.index);
       if (part.length < search.length) {
-        rewritten += before;
+
+        if(tail)
+          rewritten += tail+before;
+        else
+          rewritten += before;
+        
         tail = part;
       } else {
         totalMatches++;

--- a/test/replace.js
+++ b/test/replace.js
@@ -11,32 +11,6 @@ function script(inner) {
   ].join('\n');
 }
 describe('replace', function () {
-  it('should only replace characters specified', function (done) {
-    var haystack = [
-      'ab',
-      'a',
-      'b'
-    ].join('\n');
-
-    var acc = '';
-    var replace = replaceStream('ab','Z');
-    replace.on('data', function (data) {
-      acc += data;
-    });
-    replace.on('end', function () {
-        var expected = [
-        'Z',
-        'a',
-        'b'
-      ].join('\n');
-
-      expect(acc).to.equal(expected);
-      done();
-    });
-
-    replace.write(haystack);
-    replace.end();
-  });
 
   it('should be able to replace within a chunk', function (done) {
     var haystack = [
@@ -323,4 +297,59 @@ describe('replace', function () {
 
       replace.end();
     });
+ it('should replace characters specified and not modify partial matches', function (done) {
+    var haystack = [
+      'ab',
+      'a',
+      'a',
+      'b'
+    ].join('\n');
+
+    var acc = '';
+    var replace = replaceStream('ab','Z');
+    replace.on('data', function (data) {
+      acc += data;
+    });
+    replace.on('end', function () {
+        var expected = [
+        'Z',
+        'a',
+        'a',
+        'b'
+      ].join('\n');
+
+      expect(acc).to.equal(expected);
+      done();
+    });
+
+    replace.write(haystack);
+    replace.end();
+  });
+
+  it('should only replace characters specified', function (done) {
+    var haystack = [
+      'ab',
+      'a',
+      'b'
+    ].join('\n');
+
+    var acc = '';
+    var replace = replaceStream('ab','Z');
+    replace.on('data', function (data) {
+      acc += data;
+    });
+    replace.on('end', function () {
+        var expected = [
+        'Z',
+        'a',
+        'b'
+      ].join('\n');
+
+      expect(acc).to.equal(expected);
+      done();
+    });
+
+    replace.write(haystack);
+    replace.end();
+  });
 });


### PR DESCRIPTION
Fixed issue that occurs when multiple partial matches are found.  The logic needs to append the tail to the rewritten stream, when one exists, otherwise it gets removed.

fixes #5
