### PR TITLE
Set options.limit to 1 for non-global string matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ Happy earthday to you!
 NB: If your readable Stream that you're piping through the `replacestream` is
 paused, then you may have to call the `.resume()` method on it.
 
+## Configuration
+
 ### Changing the encoding
 
 You can also change the text encoding of the search and replace by setting an
@@ -232,6 +234,17 @@ fs.createReadStream(path.join(__dirname, 'happybirthday.txt'))
 ```
 
 By default the encoding will be set to 'utf8'.
+
+## List of options
+
+Option        | Default   | Description
+------        | -------   | -----------
+limit         | Infinity  | Sets a limit on the number of times the replacement will be made. This is forced to one when a regex without the global flag is provided.
+encoding      | utf8      | The text encoding used during search and replace.
+max_match_len | 100       | When doing cross-chunk replacing, this sets the maximum length match that will be supported.
+ignoreCase    | true      | When doing string match (not relevant for regex matching) whether to do a case insensitive search.
+regExpOptions | undefined | (Deprecated) When provided, these flags will be used when creating the search regexes internally. This functionality is deprecated as the flags set on the regex provided are no longer mutated if this is not provided.
+
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -122,7 +122,11 @@ function escapeRegExp(s) {
     return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
-function matchFromRegex(regex, options) {
+function matchFromRegex(s, options) {
+  var regex = s
+  if (options.regExpOptions)
+    regex = new RegExp(s.source, options.regExpOptions)
+
   // If there is no global flag then there can only be one match
   if (!regex.global) {
     options.limit = 1;
@@ -131,5 +135,8 @@ function matchFromRegex(regex, options) {
 }
 
 function matchFromString(s, options) {
+  if (options.regExpOptions)
+    return new RegExp(escapeRegExp(s), options.regExpOptions)
+
   return new RegExp(escapeRegExp(s), options.ignoreCase === false ? 'gm' : 'gmi')
 }

--- a/index.js
+++ b/index.js
@@ -139,5 +139,9 @@ function matchFromRegex(s, options) {
 }
 
 function matchFromString(s, options) {
+  // If there is no global flag then there can only be one match
+  if (options.regExpOptions.indexOf('g') < 0) {
+    options.limit = 1;
+  }
   return new RegExp(escapeRegExp(s), options.regExpOptions);
 }

--- a/index.js
+++ b/index.js
@@ -11,9 +11,6 @@ function ReplaceStream(search, replace, options) {
   options.encoding = options.encoding || 'utf8';
   options.max_match_len = options.max_match_len || 100;
 
-  if (!isRegex)
-    options.regExpOptions = options.regExpOptions || 'gmi';
-
   var replaceFn = replace;
 
   replaceFn = createReplaceFn(replace, isRegex);
@@ -125,23 +122,14 @@ function escapeRegExp(s) {
     return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
-function matchFromRegex(s, options) {
-  if (options.regExpOptions) {
-    return new RegExp(s.source, options.regExpOptions)
-  } else {
-    var flags = s.toString().replace(/\/[^\/].*\//, '')
-    // If there is no global flag then there can only be one match
-    if (flags.indexOf('g') < 0) {
-      options.limit = 1;
-    }
-    return new RegExp(s.source, flags)
+function matchFromRegex(regex, options) {
+  // If there is no global flag then there can only be one match
+  if (!regex.global) {
+    options.limit = 1;
   }
+  return regex
 }
 
 function matchFromString(s, options) {
-  // If there is no global flag then there can only be one match
-  if (options.regExpOptions.indexOf('g') < 0) {
-    options.limit = 1;
-  }
-  return new RegExp(escapeRegExp(s), options.regExpOptions);
+  return new RegExp(escapeRegExp(s), options.ignoreCase === false ? 'gm' : 'gmi')
 }

--- a/test/replace.js
+++ b/test/replace.js
@@ -300,6 +300,60 @@ describe('replace', function () {
       replace.end();
     });
 
+  it('should be able to customize the regexp options - deprecated',
+    function (done) {
+      var haystacks = [
+        [ '<!DOCTYPE html>',
+          '<html>',
+          ' <head>',
+          '   <title>Test</title>',
+          ' </head>',
+          ' <body>',
+          ' <P> Hello 1</P>',
+          ' <P> Hello 2</'
+        ].join('\n'),
+        [               'P>',
+          ' <P> Hello 3</P>',
+          ' <p> Hello 4</p>',
+          ' <p> Hello 5</p>',
+          ' </body>',
+          '</html>'
+        ].join('\n'),
+      ];
+
+      var acc = '';
+      var inject = script(fs.readFileSync('./test/fixtures/inject.js'));
+      var replace = replaceStream('</P>', ', world</P>', { regExpOptions: 'gm' });
+      replace.on('data', function (data) {
+        acc += data;
+      });
+      replace.on('end', function () {
+        var expected = [
+          '<!DOCTYPE html>',
+          '<html>',
+          ' <head>',
+          '   <title>Test</title>',
+          ' </head>',
+          ' <body>',
+          ' <P> Hello 1, world</P>',
+          ' <P> Hello 2, world</P>',
+          ' <P> Hello 3, world</P>',
+          ' <p> Hello 4</p>',
+          ' <p> Hello 5</p>',
+          ' </body>',
+          '</html>'
+        ].join('\n');
+        expect(acc).to.equal(expected);
+        done();
+      });
+
+      haystacks.forEach(function (haystack) {
+        replace.write(haystack);
+      });
+
+      replace.end();
+    });
+
  it('should replace characters specified and not modify partial matches', function (done) {
     var haystack = [
       'ab',
@@ -699,6 +753,60 @@ describe('replace', function () {
             ' <p> Hello 1, world</p>',
             ' <p> Hello 2, world</p>',
             ' <p> Hello 3, world</p>',
+            ' <p> Hello 4</p>',
+            ' <p> Hello 5</p>',
+            ' </body>',
+            '</html>'
+          ].join('\n');
+          expect(acc).to.equal(expected);
+          done();
+        });
+
+        haystacks.forEach(function (haystack) {
+          replace.write(haystack);
+        });
+
+        replace.end();
+      });
+
+    it('should be able to customize the regexp options using regex - deprecated',
+      function (done) {
+        var haystacks = [
+          [ '<!DOCTYPE html>',
+            '<html>',
+            ' <head>',
+            '   <title>Test</title>',
+            ' </head>',
+            ' <body>',
+            ' <P> Hello 1</P>',
+            ' <P> Hello 2</'
+          ].join('\n'),
+          [               'P>',
+            ' <P> Hello 3</P>',
+            ' <p> Hello 4</p>',
+            ' <p> Hello 5</p>',
+            ' </body>',
+            '</html>'
+          ].join('\n'),
+        ];
+
+        var acc = '';
+        var inject = script(fs.readFileSync('./test/fixtures/inject.js'));
+        var replace = replaceStream(/<\/P>/, ', world</P>', { regExpOptions: 'gm' });
+        replace.on('data', function (data) {
+          acc += data;
+        });
+        replace.on('end', function () {
+          var expected = [
+            '<!DOCTYPE html>',
+            '<html>',
+            ' <head>',
+            '   <title>Test</title>',
+            ' </head>',
+            ' <body>',
+            ' <P> Hello 1, world</P>',
+            ' <P> Hello 2, world</P>',
+            ' <P> Hello 3, world</P>',
             ' <p> Hello 4</p>',
             ' <p> Hello 5</p>',
             ' </body>',

--- a/test/replace.js
+++ b/test/replace.js
@@ -74,6 +74,62 @@ describe('replace', function () {
     replace.end();
   });
 
+  it('should default to case insensitive string matches', function (done) {
+    var haystack = [
+      '<!DOCTYPE html>',
+      '<html>',
+      ' <head>',
+      '   <title>Test</title>',
+      ' </head>',
+      ' <body>',
+      '   <h1>Head</h1>',
+      ' </body>',
+      '</html>'
+    ].join('\n');
+
+    var acc = '';
+    var inject = script(fs.readFileSync('./test/fixtures/inject.js'));
+    var replace = replaceStream('</HEAD>', inject + '</head>');
+    replace.on('data', function (data) {
+      acc += data;
+    });
+    replace.on('end', function () {
+      expect(acc).to.include(inject);
+      done();
+    });
+
+    replace.write(haystack);
+    replace.end();
+  });
+
+  it('should be possible to force case sensitive string matches', function (done) {
+    var haystack = [
+      '<!DOCTYPE html>',
+      '<html>',
+      ' <head>',
+      '   <title>Test</title>',
+      ' </head>',
+      ' <body>',
+      '   <h1>Head</h1>',
+      ' </body>',
+      '</html>'
+    ].join('\n');
+
+    var acc = '';
+    var inject = script(fs.readFileSync('./test/fixtures/inject.js'));
+    var replace = replaceStream('</HEAD>', inject + '</head>', { ignoreCase: false });
+    replace.on('data', function (data) {
+      acc += data;
+    });
+    replace.on('end', function () {
+      expect(acc).to.not.include(inject);
+      done();
+    });
+
+    replace.write(haystack);
+    replace.end();
+  });
+
   it('should be able to handle no matches', function (done) {
     var haystacks = [
       [ '<!DOCTYPE html>',
@@ -228,60 +284,6 @@ describe('replace', function () {
           ' <p> Hello 1, world</p>',
           ' <p> Hello 2, world</p>',
           ' <p> Hello 3, world</p>',
-          ' <p> Hello 4</p>',
-          ' <p> Hello 5</p>',
-          ' </body>',
-          '</html>'
-        ].join('\n');
-        expect(acc).to.equal(expected);
-        done();
-      });
-
-      haystacks.forEach(function (haystack) {
-        replace.write(haystack);
-      });
-
-      replace.end();
-    });
-
-  it('should be able to customize the regexp options',
-    function (done) {
-      var haystacks = [
-        [ '<!DOCTYPE html>',
-          '<html>',
-          ' <head>',
-          '   <title>Test</title>',
-          ' </head>',
-          ' <body>',
-          ' <P> Hello 1</P>',
-          ' <P> Hello 2</'
-        ].join('\n'),
-        [               'P>',
-          ' <P> Hello 3</P>',
-          ' <p> Hello 4</p>',
-          ' <p> Hello 5</p>',
-          ' </body>',
-          '</html>'
-        ].join('\n'),
-      ];
-
-      var acc = '';
-      var inject = script(fs.readFileSync('./test/fixtures/inject.js'));
-      var replace = replaceStream('</P>', ', world</P>', { regExpOptions: 'gm' });
-      replace.on('data', function (data) {
-        acc += data;
-      });
-      replace.on('end', function () {
-        var expected = [
-          '<!DOCTYPE html>',
-          '<html>',
-          ' <head>',
-          '   <title>Test</title>',
-          ' </head>',
-          ' <body>',
-          ' <P> Hello 1, world</P>',
-          ' <P> Hello 2, world</P>',
-          ' <P> Hello 3, world</P>',
           ' <p> Hello 4</p>',
           ' <p> Hello 5</p>',
           ' </body>',
@@ -713,7 +715,7 @@ describe('replace', function () {
         replace.end();
       });
 
-    it('should be able to customize the regexp options using regex',
+    it('should be possible to specify the regexp flags when using a regex',
       function (done) {
         var haystacks = [
           [ '<!DOCTYPE html>',
@@ -736,7 +738,7 @@ describe('replace', function () {
 
         var acc = '';
         var inject = script(fs.readFileSync('./test/fixtures/inject.js'));
-        var replace = replaceStream(/<\/P>/, ', world</P>', { regExpOptions: 'gm' });
+        var replace = replaceStream(/<\/P>/gm, ', world</P>');
         replace.on('data', function (data) {
           acc += data;
         });


### PR DESCRIPTION
When doing string matching and using regExpOptions without the global flag, it's
possible to get in an infinite loop. Use the same check as matchFromRegex to
avoid that.


Was mucking around with some replacing, and found I was in an infinite loop because of this, so thought it might be helpful? :-)