### PR TITLE
Ensure that replacements are performed to the tail

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var through = require('through');
 module.exports = ReplaceStream;
 function ReplaceStream(search, replace, options) {
   var tail = '';
+  var processedTail = '';
   var totalMatches = 0;
   var isRegex = search instanceof RegExp;
 
@@ -34,6 +35,7 @@ function ReplaceStream(search, replace, options) {
     var rewritten = '';
     var haystack = tail + buf.toString(options.encoding);
     tail = '';
+    processedTail = '';
 
     while (totalMatches < options.limit &&
           (matches = match.exec(haystack)) !== null) {
@@ -45,6 +47,7 @@ function ReplaceStream(search, replace, options) {
 
       if (lastPos == haystack.length && regexMatch[0].length < options.max_match_len) {
         tail = regexMatch[0]
+        processedTail = getDataToAppend(before,regexMatch)
       } else {
         var dataToAppend = getDataToAppend(before,regexMatch);
         rewritten += dataToAppend;
@@ -85,7 +88,8 @@ function ReplaceStream(search, replace, options) {
   }
 
   function end() {
-    if (tail) this.queue(tail);
+    if (processedTail) this.queue(processedTail);
+    else if (tail) this.queue(tail);
     this.queue(null);
   }
 

--- a/index.js
+++ b/index.js
@@ -35,6 +35,11 @@ function ReplaceStream(search, replace, options) {
     var rewritten = '';
     var haystack = tail + buf.toString(options.encoding);
     tail = '';
+    // If we have a value for processedTail we've incremented totalMatches, but
+    // if we've got a new chunk, then processedTail won't be used so undo the
+    // totalMatches increment
+    if(processedTail)
+      totalMatches--;
     processedTail = '';
 
     while (totalMatches < options.limit &&

--- a/test/replace.js
+++ b/test/replace.js
@@ -999,7 +999,7 @@ describe('replace', function () {
 
       var acc = '';
       var inject = script(fs.readFileSync('./test/fixtures/inject.js'));
-      var replace = replaceStream(/<\/html>/g, inject + '</html>');
+      var replace = replaceStream(/<\/html>/, inject + '</html>');
       replace.on('data', function (data) {
         acc += data;
       });

--- a/test/replace.js
+++ b/test/replace.js
@@ -984,4 +984,31 @@ describe('replace', function () {
         replace.write(haystack);
         replace.end();
       })
+    it('should be able to replace when the match is a tail using a regex', function (done) {
+      var haystack = [
+        '<!DOCTYPE html>',
+        '<html>',
+        ' <head>',
+        '   <title>Test</title>',
+        ' </head>',
+        ' <body>',
+        '   <h1>Head</h1>',
+        ' </body>',
+        '</html>'
+      ].join('\n');
+
+      var acc = '';
+      var inject = script(fs.readFileSync('./test/fixtures/inject.js'));
+      var replace = replaceStream(/<\/html>/g, inject + '</html>');
+      replace.on('data', function (data) {
+        acc += data;
+      });
+      replace.on('end', function () {
+        expect(acc).to.include(inject);
+        done();
+      });
+
+      replace.write(haystack);
+      replace.end();
+    });
 });

--- a/test/replace.js
+++ b/test/replace.js
@@ -1011,4 +1011,34 @@ describe('replace', function () {
       replace.write(haystack);
       replace.end();
     });
+    it('should be correctly limit replacements when the match is a tail using a regex', function (done) {
+      var haystacks = [
+        'a',
+        'a',
+        'b',
+        'a'
+      ]
+
+      var acc = '';
+      var replace = replaceStream(/a/ig, 'c', { limit: 2 })
+      replace.on('data', function (data) {
+        acc += data;
+      });
+      replace.on('end', function () {
+        var expected = [
+          'c',
+          'c',
+          'b',
+          'a'
+        ].join('');
+
+        expect(acc).to.equal(expected);
+        done();
+      });
+
+      haystacks.forEach(function (haystack) {
+        replace.write(haystack);
+      });
+      replace.end();
+    });
 });


### PR DESCRIPTION
If the match occurs on the last character, the replacement isn't correctly
processed.

This adds support for that scenario.


This _seems_ to be working for my scenario, and I added a test to check (and all other tests still pass) but I'm kinda concerned that this will break something :-s

The issue is a double barrel of:
 - an infinite loop when the match finishes on the last character of the input, and the `totalMatches` is never incremented - and if the regex is non-global; it keeps matching (hence infinite)
 - and, the data in the tail is then outputted unchanged (ie the replacement isn't performed) because the `end` flushes `tail` - but it hasn't had the change applied in the lastPos check.


Now that I think about it, I think this will break the totalMatches counter when it's not the end (because it will have been incremented twice for the one chunk (because the tail is processed a second time)). Will go look at that :-)

Again, I think this may be a bad fix... As I wasn't sure the most logical way to do it... I had a very specific scenario to fix, and I think this may break more general, existing, usages.