### PR TITLE
Switch from Streams1 to Streams3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: false
 language: node_js
 node_js:
-  - "0.10"
+  - iojs
+  - node
+  - '0.10'

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "replacestream",
   "version": "2.1.0",
   "description": "A node.js through stream that does basic streaming text search and replace and is chunk boundary friendly",
-  "main": "index.js",
+  "repository": "eugeneware/replacestream",
+  "author": "Eugene Ware <eugene@noblesamurai.com>",
+  "license": "BSD-3-Clause",
+  "files": [
+    "index.js"
+  ],
   "scripts": {
-    "test": "node_modules/.bin/mocha"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/eugeneware/replacestream"
+    "test": "mocha --growl --full-trace"
   },
   "keywords": [
     "replace",
@@ -19,13 +20,14 @@
     "streaming",
     "search"
   ],
-  "author": "Eugene Ware <eugene@noblesamurai.com>",
-  "license": "BSD",
-  "devDependencies": {
-    "chai": "^1.9.1",
-    "mocha": "^1.21.4"
-  },
   "dependencies": {
-    "through": "~2.3.4"
+    "escape-string-regexp": "^1.0.3",
+    "object-assign": "^3.0.0",
+    "readable-stream": "^2.0.1"
+  },
+  "devDependencies": {
+    "chai": "^3.0.0",
+    "concat-stream": "^1.5.0",
+    "mocha": "^2.2.5"
   }
 }

--- a/test/fixtures/inject.js
+++ b/test/fixtures/inject.js
@@ -1,4 +1,0 @@
-console.log('hello');
-document.addEventListener("DOMContentLoaded", function () {
-  document.body.style.backgroundColor = "red";
-});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,0 @@
---reporter spec
---ui bdd
---growl


### PR DESCRIPTION
The current latest version of replacestream uses Streams1 via the [through](https://github.com/dominictarr/through) module but Streams1 is the really older implementation. Actually Node v0.10 that uses Streams2 instead of Streams1 was released in [Mar 2013](http://blog.nodejs.org/2013/03/11/node-v0-10-0-stable/).

This PR replaces through 0.6 with [readable-stream](https://github.com/nodejs/readable-stream) v2.0.0 to switch to Streams3 which is a more popular stream implementation as it's used in the latest Node and io.js.
