### PR TITLE
Fix strange bug with regexes

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,16 @@ module.exports = function ReplaceStream(search, replace, options) {
     var haystack = tail + buf.toString(options.encoding);
     tail = '';
 
-    while (totalMatches < options.limit &&
-          (matches = match.exec(haystack)) !== null) {
+    while (totalMatches < options.limit) {
+
+      //
+      // For some reason this is necessary to work (at least on v5.1.0).
+      // Otherwise, the lastIndex never updates past the first iteration.
+      match.lastIndex = lastPos
+      //
+
+      matches = match.exec(haystack)
+      if (matches === null) break;
 
       matchCount++;
       var before = haystack.slice(lastPos, matches.index);


### PR DESCRIPTION
For some reason the regex isn't   isn't updating x as it should.
I tried isolating, but no luck.
This fix is a bit more code, but it's good according to the spec,
so there should be no issues with backwards compatibility.