### PR TITLE
Fix replace of captures

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ function createReplaceFn(replace, isRegEx) {
     // And string parameters
     var paramLength = arguments.length - 2;
     for (var i = 1; i < paramLength; i++) {
-      newReplace = newReplace.replace('$' + i, arguments[i] || '')
+      newReplace = newReplace.replace(new RegExp('\\$' + i, 'g'), arguments[i] || '')
     }
     return newReplace;
   };

--- a/test/replace.js
+++ b/test/replace.js
@@ -872,12 +872,12 @@ describe('replacestream', function () {
       });
 
       it('should be able to replace captures using $1 notation', function (done) {
-        var replace = replaceStream(/(a)(b)/g, 'this is $1 and this is $2');
+        var replace = replaceStream(/(a)(b)/g, 'this is $1 and this is $2 and this is again $1');
         replace.pipe(concatStream({encoding: 'string'}, function(data) {
           var expected = [
-            'this is a and this is b',
+            'this is a and this is b and this is again a',
             'a',
-            'this is a and this is b',
+            'this is a and this is b and this is again a',
             'b'
           ].join('\n');
 


### PR DESCRIPTION
The issue is when we have multiple same captures in the replacement string like:

`replaceStream(/(a)/, '$1-$1')`

In the current implementation only the first occurrence of the capture in replacement string is replaced. This is caused by using the string `replace` method, that replaces only first match in target string given string pattern argument.

This fix is using Regex to replace all occurrences of same captures in replacement string.

