### PR TITLE
Fixed incorrect tail handling caused by missing .length

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = function ReplaceStream(search, replace, options) {
     }
 
     if (tail.length < 1)
-      tail = haystack.slice(lastPos) > options.maxMatchLen ? haystack.slice(lastPos).slice(0 - options.maxMatchLen) : haystack.slice(lastPos)
+      tail = haystack.slice(lastPos).length > options.maxMatchLen ? haystack.slice(lastPos).slice(0 - options.maxMatchLen) : haystack.slice(lastPos)
 
     var dataToQueue = getDataToQueue(matchCount,haystack,rewritten,lastPos);
     cb(null, dataToQueue);

--- a/test/replace.js
+++ b/test/replace.js
@@ -3,6 +3,7 @@
 var concatStream = require('concat-stream');
 var expect = require('chai').expect;
 var replaceStream = require('..');
+var stream = require('stream')
 
 var script = [
   '<script type="text/javascript">',
@@ -909,5 +910,27 @@ describe('replacestream', function () {
       ' </body>',
       '</html>'
     ].join('\n'));
+  });
+
+  it('should push chunks immediately except tail', function (done) {
+    var replace = replaceStream(/REPLACE/, '')
+    var replaced = new stream.PassThrough
+
+    let recievedChunks = []
+    replace.pipe(replaced)
+    replaced.on('data', function(data) {
+      recievedChunks.push(data)
+    })
+    replaced.on('end', function() {
+      expect(recievedChunks.length).to.equal(3)
+      expect(recievedChunks[0]).to.have.length(99)
+      expect(recievedChunks[1]).to.have.length(50)
+      expect(recievedChunks[1]).to.have.length(100)
+      done()
+    })
+    replace.write(Buffer.alloc(50))
+    replace.write(Buffer.alloc(49))
+    replace.write(Buffer.alloc(100))
+    replace.end(Buffer.alloc(50))
   });
 });

--- a/test/replace.js
+++ b/test/replace.js
@@ -925,12 +925,12 @@ describe('replacestream', function () {
       expect(recievedChunks.length).to.equal(3)
       expect(recievedChunks[0]).to.have.length(99)
       expect(recievedChunks[1]).to.have.length(50)
-      expect(recievedChunks[1]).to.have.length(100)
+      expect(recievedChunks[2]).to.have.length(100)
       done()
     })
-    replace.write(Buffer.alloc(50))
-    replace.write(Buffer.alloc(49))
-    replace.write(Buffer.alloc(100))
-    replace.end(Buffer.alloc(50))
+    replace.write((new Buffer(50)).fill(0))
+    replace.write((new Buffer(49)).fill(0))
+    replace.write((new Buffer(100)).fill(0))
+    replace.end((new Buffer(50)).fill(0))
   });
 });

--- a/test/replace.js
+++ b/test/replace.js
@@ -916,7 +916,7 @@ describe('replacestream', function () {
     var replace = replaceStream(/REPLACE/, '')
     var replaced = new stream.PassThrough
 
-    let recievedChunks = []
+    var recievedChunks = []
     replace.pipe(replaced)
     replaced.on('data', function(data) {
       recievedChunks.push(data)


### PR DESCRIPTION
https://github.com/eugeneware/replacestream/blob/master/index.js#L56
```js
haystack.slice(lastPos) > options.maxMatchLen
```
```js
haystack.slice(lastPos).length > options.maxMatchLen
```
the missing ```.length``` led to appended the data always to tail instead of only  ```options.maxMatchLen``` bytes


### edit:
tests are still failing on v0.10 because of the way of creating deterministic chunks
- ```Buffer.alloc()``` fails on <v6.0
- ```(new Buffer).fill(0)``` fails on v0.10. throws ```TypeError: Cannot read property 'length' of undefined```

if somebody wanna work on that: feel free!